### PR TITLE
Add CSS classes for exotic ANSI modes

### DIFF
--- a/assets/css/typography.less
+++ b/assets/css/typography.less
@@ -1,5 +1,10 @@
 @import (reference) "_vars.less";
 
+@font-face {
+  font-family: "UnifrakturCook";
+  src: url("https://fonts.googleapis.com/css?family=UnifrakturCook:700");
+}
+
 h1, .h1 {
   line-height: 60px;
   color: @base07;
@@ -17,6 +22,13 @@ h3, .h3 {
 
 /* ansi text */
 .ansi-bold { font-weight: bold; }
+.ansi-faint { color: darken(@base05, 50%) }
+.ansi-Fraktur { font-family: 'UnifrakturCook', cursive; }
+.ansi-framed {
+  background-color: darken(@base05, 70%);
+  border: 1px solid darken(@base05, 50%);
+  border-radius: 5px;
+}
 
 .ansi-black-fg { color: @base03; }
 .ansi-red-fg { color: @base08; }


### PR DESCRIPTION
Filling in for faint (which was supported but didn't have a class) and adding support for Fraktur and framed via https://github.com/vito/elm-ansi/pull/2, this adds rendering for these exotic modes.

Users can use them to make their build outputs easier to follow beyond just using the basic ansi colors. The framed css is simple and could be changed to whatever framing style y'all deem necessary.

Examples:

Faint:
<img width="597" alt="build-tests 21 - concourse 2018-02-03 16-13-41" src="https://user-images.githubusercontent.com/7/35773097-3e5bf29c-08fd-11e8-83c4-12ff2321d32e.png">

Fraktur:
<img width="225" alt="build-tests 21 - concourse 2018-02-03 16-14-34" src="https://user-images.githubusercontent.com/7/35773098-5e603a58-08fd-11e8-9325-2d8682a4f6e9.png">

