### PR TITLE
Fix off-by-one timestamps

### DIFF
--- a/elm/src/Beta/BetaBuildOutput.elm
+++ b/elm/src/Beta/BetaBuildOutput.elm
@@ -259,7 +259,7 @@ appendStepLog output mtime tree =
                     List.foldl
                         setLineTimestamp
                         step.timestamps
-                        (List.range 1 (Array.length newLog.lines))
+                        (List.range 0 ((Array.length newLog.lines) - 1))
             in
                 { step | log = newLog, timestamps = newTimestamps }
 

--- a/elm/src/BuildOutput.elm
+++ b/elm/src/BuildOutput.elm
@@ -259,7 +259,7 @@ appendStepLog output mtime tree =
                     List.foldl
                         setLineTimestamp
                         step.timestamps
-                        (List.range 1 (Array.length newLog.lines))
+                        (List.range 0 ((Array.length newLog.lines) - 1))
             in
                 { step | log = newLog, timestamps = newTimestamps }
 


### PR DESCRIPTION
The timestamp gutter is currently off by one line, creating quite a bit of confusion. This fixes this issue by just having the line numbers start at 0 instead of 1.