### PR TITLE
URI encode slashes in job names when building urls

### DIFF
--- a/elm/src/Concourse/Build.elm
+++ b/elm/src/Concourse/Build.elm
@@ -38,6 +38,6 @@ fetchJobBuilds : Concourse.JobIdentifier -> Maybe Page -> Task Http.Error (Pagin
 fetchJobBuilds job page =
     let
         url =
-            "/api/v1/teams/" ++ job.teamName ++ "/pipelines/" ++ job.pipelineName ++ "/jobs/" ++ job.jobName ++ "/builds"
+            "/api/v1/teams/" ++ job.teamName ++ "/pipelines/" ++ job.pipelineName ++ "/jobs/" ++ Http.encodeUri(job.jobName) ++ "/builds"
     in
         Concourse.Pagination.fetch Concourse.decodeBuild url page

--- a/elm/src/Concourse/Job.elm
+++ b/elm/src/Concourse/Job.elm
@@ -15,7 +15,7 @@ fetchJob job =
     Http.toTask <|
         flip Http.get
             (Concourse.decodeJob { teamName = job.teamName, pipelineName = job.pipelineName })
-            ("/api/v1/teams/" ++ job.teamName ++ "/pipelines/" ++ job.pipelineName ++ "/jobs/" ++ job.jobName)
+            ("/api/v1/teams/" ++ job.teamName ++ "/pipelines/" ++ job.pipelineName ++ "/jobs/" ++ Http.encodeUri(job.jobName))
 
 
 fetchJobs : Concourse.PipelineIdentifier -> Task Http.Error (List Concourse.Job)
@@ -44,7 +44,7 @@ fetchJobsRaw pi =
 
 triggerBuild : Concourse.JobIdentifier -> Concourse.CSRFToken -> Task Http.Error Concourse.Build
 triggerBuild job csrfToken =
-    HttpBuilder.post ("/api/v1/teams/" ++ job.teamName ++ "/pipelines/" ++ job.pipelineName ++ "/jobs/" ++ job.jobName ++ "/builds")
+    HttpBuilder.post ("/api/v1/teams/" ++ job.teamName ++ "/pipelines/" ++ job.pipelineName ++ "/jobs/" ++ Http.encodeUri(job.jobName) ++ "/builds")
         |> HttpBuilder.withHeader Concourse.csrfTokenHeaderName csrfToken
         |> HttpBuilder.withExpect (Http.expectJson (Concourse.decodeBuild))
         |> HttpBuilder.toTask


### PR DESCRIPTION
Job names can contain slashes and this was causing 404s.